### PR TITLE
remove `#readme` from `more` link

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,8 +65,9 @@ module.exports = function (options) {
 
 function toLink(pkg, num, words) {
   var res = '';
-  res += link(pkg.name, pkg.homepage);
-  res += truncate(pkg.description, pkg.homepage, words);
+  var homepage = pkg.homepage.replace('#readme', '')
+  res += link(pkg.name, homepage);
+  res += truncate(pkg.description, homepage, words);
   if (num <= 1) return res;
   return '* ' + res;
 }
@@ -95,7 +96,7 @@ function truncate(description, homepage, words) {
   res = arr.slice(0, max).join(' ');
 
   if (res.length < description.length) {
-    res += '… [more](' + homepage.replace('#readme', '') + ')';
+    res += '… [more](' + homepage + ')';
   }
   return ': ' + res;
 }

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = function (options) {
 
 function toLink(pkg, num, words) {
   var res = '';
-  var homepage = pkg.homepage.replace('#readme', '')
+  var homepage = pkg.homepage.split('#readme').join('')
   res += link(pkg.name, homepage);
   res += truncate(pkg.description, homepage, words);
   if (num <= 1) return res;

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ function truncate(description, homepage, words) {
   res = arr.slice(0, max).join(' ');
 
   if (res.length < description.length) {
-    res += '… [more](' + homepage + ')';
+    res += '… [more](' + homepage.replace('#readme', '') + ')';
   }
   return ': ' + res;
 }

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = function (options) {
 
 function toLink(pkg, num, words) {
   var res = '';
-  var homepage = pkg.homepage.split('#readme').join('')
+  var homepage = pkg.homepage.replace(/#readme$/, '');
   res += link(pkg.name, homepage);
   res += truncate(pkg.description, homepage, words);
   if (num <= 1) return res;

--- a/test.js
+++ b/test.js
@@ -14,73 +14,81 @@ var related = require('./')();
 
 describe('related', function () {
   it('should get a package.json from npm:', function (cb) {
-    related('verb', function (err, res) {
-      res.should.match(/\[verb\]/);
+    this.timeout(10000)
+    related('always-thunk', function (err, res) {
+      res.should.match(/\[always-thunk\]/);
       cb();
     });
   });
 
   it('should get an array of package.json files:', function (cb) {
-    related(['remarkable', 'micromatch'], function (err, res) {
-      res.should.match(/\[remarkable\]/);
-      res.should.match(/\[micromatch\]/);
+    this.timeout(10000)
+    related(['always-thunk', 'promise2thunk'], function (err, res) {
+      res.should.match(/\[always-thunk\]/);
+      res.should.match(/\[promise2thunk\]/);
       cb();
     });
   });
 
   it('should remove a name passed on `options.remove`:', function (cb) {
-    var list = ['remarkable', 'micromatch', 'verb', 'assemble'];
-    related(list, {remove: 'verb'}, function (err, res) {
-      res.should.match(/\[assemble\]/);
-      res.should.not.match(/\[verb\]/);
-      res.should.match(/\[remarkable\]/);
-      res.should.match(/\[micromatch\]/);
+    this.timeout(10000)
+    var list = ['promise2thunk', 'always-callback', 'make-callback', 'ip-filter'];
+    related(list, {remove: 'make-callback'}, function (err, res) {
+      res.should.match(/\[promise2thunk\]/);
+      res.should.not.match(/\[make-callback\]/);
+      res.should.match(/\[always-callback\]/);
+      res.should.match(/\[ip-filter\]/);
       cb();
     });
   });
 
   it('should remove an array of names passed on `options.remove`:', function (cb) {
-    var list = ['remarkable', 'micromatch', 'verb', 'assemble'];
-    related(list, {remove: ['verb', 'micromatch']}, function (err, res) {
-      res.should.match(/\[assemble\]/);
-      res.should.not.match(/\[verb\]/);
-      res.should.match(/\[remarkable\]/);
-      res.should.not.match(/\[micromatch\]/);
+    this.timeout(10000)
+    var list = ['promise2thunk', 'always-callback', 'make-callback', 'ip-filter'];
+    related(list, {remove: ['make-callback', 'always-callback']}, function (err, res) {
+      res.should.match(/\[promise2thunk\]/);
+      res.should.not.match(/\[make-callback\]/);
+      res.should.not.match(/\[always-callback\]/);
+      res.should.match(/\[ip-filter\]/);
       cb();
     });
   });
 
   it('should truncate description to 15 words by default', function (cb) {
-    related(['micromatch', 'assemble'], function (err, res) {
+    this.timeout(10000)
+    related(['is-es6-generators', 'always-callback'], function (err, res) {
       res.should.equal([
-        '* [assemble](http://assemble.io): Static site generator for Grunt.js, Yeoman and Node.js. Used by Zurb Foundation, Zurb Ink, H5BP/Effeckt,… [more](http://assemble.io)',
-        '* [micromatch](https://github.com/jonschlinkert/micromatch): Glob matching for javascript/node.js. A drop-in replacement and faster alternative to minimatch and multimatch. Just… [more](https://github.com/jonschlinkert/micromatch)'
+        '* [always-callback](https://github.com/tunnckocore/always-callback): Create callback api for given sync function. Guarantee that given function (sync or async, no… [more](https://github.com/tunnckocore/always-callback)',
+        '* [is-es6-generators](https://github.com/tunnckocore/is-es6-generators): Check whether a value is a `Generator` or `GeneratorFunction`. The `co` way, more strict checking.… [more](https://github.com/tunnckocore/is-es6-generators)'
       ].join('\n'));
       cb();
     });
   });
 
   it('should truncate the description to the given number of words:', function (cb) {
-    related(['remarkable', 'micromatch'], {words: 10}, function (err, res) {
+    this.timeout(10000)
+    related(['always-callback', 'ip-filter'], {words: 10}, function (err, res) {
       res.should.equal([
-        '* [micromatch](https://github.com/jonschlinkert/micromatch): Glob matching for javascript/node.js. A drop-in replacement and faster alternative… [more](https://github.com/jonschlinkert/micromatch)',
-        '* [remarkable](https://github.com/jonschlinkert/remarkable): Markdown parser, done right. 100% Commonmark support, extensions, syntax plugins,… [more](https://github.com/jonschlinkert/remarkable)'
+        '* [always-callback](https://github.com/tunnckocore/always-callback): Create callback api for given sync function. Guarantee that given… [more](https://github.com/tunnckocore/always-callback)',
+        '* [ip-filter](https://github.com/tunnckocore/ip-filter): Filter valid IPv4 or IPv6 IP against glob pattern, array,… [more](https://github.com/tunnckocore/ip-filter)'
       ].join('\n'));
       cb();
     });
   });
 
   it('should truncate description to 15 when truncate:true', function (cb) {
-    related(['micromatch', 'assemble'], function (err, res) {
+    this.timeout(10000)
+    related(['is-es6-generators', 'always-callback'], {truncate: true}, function (err, res) {
       res.should.equal([
-        '* [assemble](http://assemble.io): Static site generator for Grunt.js, Yeoman and Node.js. Used by Zurb Foundation, Zurb Ink, H5BP/Effeckt,… [more](http://assemble.io)',
-        '* [micromatch](https://github.com/jonschlinkert/micromatch): Glob matching for javascript/node.js. A drop-in replacement and faster alternative to minimatch and multimatch. Just… [more](https://github.com/jonschlinkert/micromatch)'
+        '* [always-callback](https://github.com/tunnckocore/always-callback): Create callback api for given sync function. Guarantee that given function (sync or async, no… [more](https://github.com/tunnckocore/always-callback)',
+        '* [is-es6-generators](https://github.com/tunnckocore/is-es6-generators): Check whether a value is a `Generator` or `GeneratorFunction`. The `co` way, more strict checking.… [more](https://github.com/tunnckocore/is-es6-generators)'
       ].join('\n'));
       cb();
     });
   });
 
   it('should not truncate description when truncate:false', function (cb) {
+    this.timeout(10000)
     related(['micromatch', 'assemble'], {truncate: false}, function (err, res) {
       res.should.equal([
         '* [assemble](http://assemble.io): Static site generator for Grunt.js, Yeoman and Node.js. Used by Zurb Foundation, Zurb Ink, H5BP/Effeckt, Less.js / lesscss.org, Topcoat, Web Experience Toolkit, and hundreds of other projects to build sites, themes, components, documentation, blogs and gh',


### PR DESCRIPTION
it's weird..? I should always remove it by hand when use `npm-related`

```
- [apidocs-cli](https://github.com/tunnckocore/apidocs-cli#readme): Async CLI for automatically generating API docs from code comments with `helper-apidocs`
- [micromatch](https://github.com/jonschlinkert/micromatch): Glob matching for javascript/node.js. A drop-in replacement and faster alternative to minimatch and multimatch. Just… [more](https://github.com/jonschlinkert/micromatch)
- [npm-related](https://github.com/tunnckoCore/npm-related#readme): Thin wrapper on top of `helper-related` for generating a list of links to the homepages… [more](https://github.com/tunnckoCore/npm-related#readme)
```

removes that `#readme` from `more` link
