### PR TITLE
Updating dependency reflinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,14 @@
 *.sublime-*
 _gh_pages
 bower_components
-node_modules
-npm-debug.log
 actual
 test/actual
 temp
 tmp
 TODO.md
 vendor
+
+# npm
+node_modules
+npm-debug.log
+/package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 sudo: false
 language: node_js
 node_js:
-  - '5'
-  - '4'
-  - '0.12'
-  - '0.10'
+  - 'node'
+  - '10'
+  - '9'
+  - '8'
 matrix:
   fast_finish: true
   allow_failures:
-    - node_js: '4'
-    - node_js: '0.10'
-    - node_js: '0.12'

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2016, Jon Schlinkert.
+Copyright (c) 2015-present, Jon Schlinkert.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=8"
   },
   "scripts": {
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -25,18 +25,18 @@
   "dependencies": {
     "arr-union": "^3.1.0",
     "engine": "^0.1.12",
-    "extend-shallow": "^2.0.1",
+    "extend-shallow": "3.0.2",
     "lazy-cache": "^2.0.2",
     "markdown-utils": "^0.7.3",
     "reflinks": "^0.3.6"
   },
   "devDependencies": {
-    "engine-base": "^0.1.2",
-    "engine-handlebars": "^0.8.0",
-    "gulp-format-md": "^0.1.9",
-    "mocha": "^2.5.3",
-    "should": "^9.0.2",
-    "templates": "^0.24.2"
+    "engine-base": "0.1.3",
+    "engine-handlebars": "0.8.2",
+    "gulp-format-md": "1.0.0",
+    "mocha": "5.2.0",
+    "should": "13.2.1",
+    "templates": "1.2.9"
   },
   "keywords": [
     "async",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "extend-shallow": "^2.0.1",
     "lazy-cache": "^2.0.2",
     "markdown-utils": "^0.7.3",
-    "reflinks": "^0.3.4"
+    "reflinks": "^0.3.6"
   },
   "devDependencies": {
     "engine-base": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "helper-related",
   "description": "Template helper for generating a list of links to the homepages of related GitHub/npm projects.",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "homepage": "https://github.com/helpers/helper-related",
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
   "repository": "helpers/helper-related",

--- a/test/test.js
+++ b/test/test.js
@@ -2,9 +2,9 @@
 
 require('mocha');
 require('should');
-var assert = require('assert');
-var templates = require('templates');
-var helper = require('..');
+const assert = require('assert');
+const templates = require('templates');
+const helper = require('..');
 var related, app;
 
 describe('related helper', function() {
@@ -75,7 +75,7 @@ describe('related helper', function() {
     this.timeout(2000);
     related(['snapdragon', 'verb'], function(err, res) {
       assert.equal(res, [
-        '- [snapdragon](https://www.npmjs.com/package/snapdragon): snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory. | [homepage](https://github.com/jonschlinkert/snapdragon "snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory.")',
+        '- [snapdragon](https://www.npmjs.com/package/snapdragon): Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map… [more](https://github.com/here-be/snapdragon) | [homepage](https://github.com/here-be/snapdragon "Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.")',
         '- [verb](https://www.npmjs.com/package/verb): Documentation generator for GitHub projects. Verb is extremely powerful, easy to use, and is used… [more](https://github.com/verbose/verb) | [homepage](https://github.com/verbose/verb "Documentation generator for GitHub projects. Verb is extremely powerful, easy to use, and is used on hundreds of projects of all sizes to generate everything from API docs to readmes.")',
       ].join('\n'));
       cb();
@@ -97,7 +97,7 @@ describe('related helper', function() {
     this.timeout(2000);
     related(['snapdragon', 'verb'], function(err, res) {
       assert.deepEqual(res, [
-        '- [snapdragon](https://www.npmjs.com/package/snapdragon): snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory. | [homepage](https://github.com/jonschlinkert/snapdragon "snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory.")',
+        '- [snapdragon](https://www.npmjs.com/package/snapdragon): Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map… [more](https://github.com/here-be/snapdragon) | [homepage](https://github.com/here-be/snapdragon "Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.")',
         '- [verb](https://www.npmjs.com/package/verb): Documentation generator for GitHub projects. Verb is extremely powerful, easy to use, and is used… [more](https://github.com/verbose/verb) | [homepage](https://github.com/verbose/verb "Documentation generator for GitHub projects. Verb is extremely powerful, easy to use, and is used on hundreds of projects of all sizes to generate everything from API docs to readmes.")',
       ].join('\n'));
       cb();


### PR DESCRIPTION
- Update get-pkg to v0.3.6
- Update required engine version to >= 8.0
- Update travis tests
- Update all other dependencies
- Add package-lock.json to ignore files
- Bump to v0.15.3

Please do a `npm publish` in case you accept this PR.

This PR is related to https://github.com/verbose/verb-generate-readme/issues/23